### PR TITLE
New example and startupadigator removed

### DIFF
--- a/exampleProblems/Brachistochrone/Brachistochrone.m
+++ b/exampleProblems/Brachistochrone/Brachistochrone.m
@@ -1,0 +1,484 @@
+function [problem,guess] = Brachistochrone
+%Brachistochrone - Brachistochrone Control Problem
+%
+% Outputs:
+%    problem - Structure with information on the optimal control problem
+%    guess   - Guess for state, control and multipliers.
+%
+% Other m-files required: none
+% MAT-files required: none
+%
+% Copyright (C) 2019 Yuanbo Nie, Omar Faqir, and Eric Kerrigan. All Rights Reserved.
+% The contribution of Paola Falugi, Eric Kerrigan and Eugene van Wyk for the work on ICLOCS Version 1 (2010) is kindly acknowledged.
+% This code is published under the MIT License.
+% Department of Aeronautics and Department of Electrical and Electronic Engineering,
+% Imperial College London London  England, UK 
+% ICLOCS (Imperial College London Optimal Control) Version 2.5 
+% 1 Aug 2019
+% iclocs@imperial.ac.uk
+
+g = 10;
+t0 = 0; 
+tf_min = 0; tf_max = 10;
+x0 = 0; y0 = 0; v0 = 0;
+xf = 2; yf = 2;
+xmin = 0; xmax = 10;
+ymin = 0; ymax = 10;
+vmin = -50; vmax = 50;
+umin = -pi/2; umax = pi/2;
+
+%------------- BEGIN CODE --------------
+% Plant model name, used for Adigator
+InternalDynamics=@Brachistochrone_Dynamics_Internal;
+SimDynamics=@Brachistochrone_Dynamics_Internal;
+
+% Analytic derivative files (optional)
+problem.analyticDeriv.gradCost=[];
+problem.analyticDeriv.hessianLagrangian=[];
+problem.analyticDeriv.jacConst=[];
+
+% Settings file
+problem.settings=@settings_Brachistochrone;
+
+% Initial time. t0<tf
+problem.time.t0_min=t0;
+problem.time.t0_max=t0;
+guess.t0=t0;
+
+% Final time. Let tf_min=tf_max if tf is fixed.
+problem.time.tf_min=tf_min;     
+problem.time.tf_max=tf_max; 
+guess.tf=1;
+
+% Parameters bounds. pl=< p <=pu
+problem.parameters.pl=[];
+problem.parameters.pu=[];
+guess.parameters=[];
+
+% Initial conditions for system
+problem.states.x0=[x0 y0 v0];
+
+% Initial conditions for system. Bounds if x0 is free s.t. x0l=< x0 <=x0u
+problem.states.x0l=[x0 y0 v0];
+problem.states.x0u=[x0 y0 v0];
+
+% State bounds. xl=< x <=xu
+problem.states.xl=[xmin ymin vmin];
+problem.states.xu=[xmax ymax vmax];
+
+% State error bounds
+problem.states.xErrorTol_local=[1e-2 1e-2 1e-2];
+problem.states.xErrorTol_integral=[1e-2 1e-2 1e-2];
+
+% State constraint error bounds
+problem.states.xConstraintTol=[1e-2 1e-2 1e-2];
+
+
+% Terminal state bounds. xfl=< xf <=xfu
+problem.states.xfl=[xf yf vmin];
+problem.states.xfu=[xf yf vmax];
+
+% Guess the state trajectories with [x0 xf]
+guess.states(:,1)=[x0 xf];
+guess.states(:,2)=[y0 yf];
+guess.states(:,3)=[v0 6];
+
+
+
+% Number of control actions N 
+% Set problem.inputs.N=0 if N is equal to the number of integration steps.  
+% Note that the number of integration steps defined in settings.m has to be divisible 
+% by the  number of control actions N whenever it is not zero.
+
+problem.inputs.N=0;
+
+% Input bounds
+problem.inputs.ul=[umin];
+problem.inputs.uu=[umax];
+
+% Bounds on first control action
+problem.inputs.u0l=[umin];
+problem.inputs.u0u=[umax]; 
+
+% Input constraint error bounds
+problem.inputs.uConstraintTol=[0.1];
+
+% Guess the input sequences with [u0 uf]
+guess.inputs(:,1)=[0 umax];
+
+% Choose the set-points if required
+problem.setpoints.states=[];
+problem.setpoints.inputs=[];
+
+% Bounds for path constraint function gl =< g(x,u,p,t) =< gu
+problem.constraints.ng_eq=0;
+problem.constraints.gTol_eq=[];
+
+problem.constraints.gl=[];
+problem.constraints.gu=[];
+problem.constraints.gTol_neq=[];
+
+
+
+% Bounds for boundary constraints bl =< b(x0,xf,u0,uf,p,t0,tf) =< bu
+problem.constraints.bl=[];
+problem.constraints.bu=[];
+problem.constraints.bTol=[];
+
+
+% store the necessary problem parameters used in the functions
+problem.data.g = g; % [m/s2]
+
+% Get function handles and return to Main.m
+problem.data.InternalDynamics=InternalDynamics;
+problem.data.functionfg=@fg;
+problem.data.plantmodel = func2str(InternalDynamics);
+problem.functions={@L,@E,@f,@g,@avrc,@b};
+problem.sim.functions=SimDynamics;
+problem.sim.inputX=[];
+problem.sim.inputU=1:length(problem.inputs.ul);
+problem.functions_unscaled={@L_unscaled,@E_unscaled,@f_unscaled,@g_unscaled,@avrc,@b_unscaled};
+problem.data.functions_unscaled=problem.functions_unscaled;
+problem.data.ng_eq=problem.constraints.ng_eq;
+problem.constraintErrorTol=[problem.constraints.gTol_eq,problem.constraints.gTol_neq,problem.constraints.gTol_eq,problem.constraints.gTol_neq,problem.states.xConstraintTol,problem.states.xConstraintTol,problem.inputs.uConstraintTol,problem.inputs.uConstraintTol];
+
+%------------- END OF CODE --------------
+
+function stageCost=L_unscaled(x,xr,u,ur,p,t,vdat)
+
+% L_unscaled - Returns the stage cost.
+% The function must be vectorized and
+% xi, ui are column vectors taken as x(:,i) and u(:,i) (i denotes the i-th
+% variable)
+% 
+% Syntax:  stageCost = L(x,xr,u,ur,p,t,data)
+%
+% Inputs:
+%    x  - state vector
+%    xr - state reference
+%    u  - input
+%    ur - input reference
+%    p  - parameter
+%    t  - time
+%    data- structured variable containing the values of additional data used inside
+%          the function
+%
+% Output:
+%    stageCost - Scalar or vectorized stage cost
+%
+%  Remark: If the stagecost does not depend on variables it is necessary to multiply
+%          the assigned value by t in order to have right vector dimesion when called for the optimization. 
+%          Example: stageCost = 0*t;
+
+%------------- BEGIN CODE --------------
+
+
+stageCost = 0*t;
+
+%------------- END OF CODE --------------
+
+
+function boundaryCost=E_unscaled(x0,xf,u0,uf,p,t0,tf,vdat) 
+
+% E_unscaled - Returns the boundary value cost
+%
+% Syntax:  boundaryCost=E(x0,xf,u0,uf,p,tf,data)
+%
+% Inputs:
+%    x0  - state at t=0
+%    xf  - state at t=tf
+%    u0  - input at t=0
+%    uf  - input at t=tf
+%    p   - parameter
+%    tf  - final time
+%    data- structured variable containing the values of additional data used inside
+%          the function
+%
+% Output:
+%    boundaryCost - Scalar boundary cost
+%
+%------------- BEGIN CODE --------------
+
+boundaryCost=tf;
+
+%------------- END OF CODE --------------
+
+
+function bc=b_unscaled(x0,xf,u0,uf,p,t0,tf,vdat,varargin)
+
+% b_unscaled - Returns a column vector containing the evaluation of the boundary constraints: bl =< bf(x0,xf,u0,uf,p,t0,tf) =< bu
+%
+% Syntax:  bc=b(x0,xf,u0,uf,p,tf,data)
+%
+% Inputs:
+%    x0  - state at t=0
+%    xf  - state at t=tf
+%    u0  - input at t=0
+%    uf  - input at t=tf
+%    p   - parameter
+%    tf  - final time
+%    data- structured variable containing the values of additional data used inside
+%          the function
+%
+%          
+% Output:
+%    bc - column vector containing the evaluation of the boundary function 
+%
+%------------- BEGIN CODE --------------
+varargin=varargin{1};
+bc=[];
+%------------- END OF CODE --------------
+% When adpative time interval add constraint on time
+%------------- BEGIN CODE --------------
+if length(varargin)==2
+    options=varargin{1};
+    t_segment=varargin{2};
+    if ((strcmp(options.discretization,'hpLGR')) || (strcmp(options.discretization,'globalLGR')))  && options.adaptseg==1 
+        if size(t_segment,1)>size(t_segment,2)
+            bc=[bc;diff(t_segment)];
+        else
+            bc=[bc;diff(t_segment)'];
+        end
+    end
+end
+
+%------------- END OF CODE --------------
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%% Leave the following unchanged! %%
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+function stageCost=L(x,xr,u,ur,p,t,vdat)
+
+% L - Returns the stage cost.
+% Warp function
+%------------- BEGIN CODE --------------
+
+if isfield(vdat,'Xscale')
+    x=scale_variables_back( x, vdat.Xscale, vdat.Xshift );
+    if ~isempty(xr)
+        xr=scale_variables_back( xr, vdat.Xscale, vdat.Xshift );
+    end
+    u=scale_variables_back( u, vdat.Uscale, vdat.Ushift );
+    if isfield(vdat,'Pscale')
+        p=scale_variables_back( p, vdat.Pscale, vdat.Pshift );
+    end
+    if ~isempty(ur)
+        ur=scale_variables_back( ur, vdat.Uscale, vdat.Ushift );
+    end
+    if strcmp(vdat.mode.currentMode,'Feasibility')
+        stageCost=0*t;
+    else
+        stageCost=L_unscaled(x,xr,u,ur,p,t,vdat);
+    end
+else
+    if strcmp(vdat.mode.currentMode,'Feasibility')
+        stageCost=0*t;
+    else
+        stageCost=L_unscaled(x,xr,u,ur,p,t,vdat);
+    end
+end
+
+%------------- END OF CODE --------------
+
+
+function boundaryCost=E(x0,xf,u0,uf,p,t0,tf,vdat) 
+
+% E - Returns the boundary value cost
+% Warp function
+%------------- BEGIN CODE --------------
+if isfield(vdat,'Xscale')
+    x0=scale_variables_back( x0', vdat.Xscale, vdat.Xshift );
+    xf=scale_variables_back( xf', vdat.Xscale, vdat.Xshift );
+    u0=scale_variables_back( u0', vdat.Uscale, vdat.Ushift );
+    uf=scale_variables_back( uf', vdat.Uscale, vdat.Ushift );
+    if isfield(vdat,'Pscale')
+        p=scale_variables_back( p', vdat.Pscale, vdat.Pshift );
+    end
+    if strcmp(vdat.mode.currentMode,'Feasibility')
+        boundaryCost=sum(sum(p(:,end-vdat.mode.np*2+1:end)));
+    else
+        boundaryCost=E_unscaled(x0,xf,u0,uf,p,t0,tf,vdat);
+    end
+else
+    if strcmp(vdat.mode.currentMode,'Feasibility')
+        boundaryCost=sum(sum(p(:,end-vdat.mode.np*2+1:end)));
+    else
+        boundaryCost=E_unscaled(x0,xf,u0,uf,p,t0,tf,vdat);
+    end
+end
+
+
+%------------- END OF CODE --------------
+
+
+function dx = f(x,u,p,t,vdat)
+% f - Returns the ODE right hand side where x'= f(x,u,p,t)
+% Warp function
+%------------- BEGIN CODE --------------
+f_unscaled=vdat.InternalDynamics;
+if isfield(vdat,'Xscale')
+    x=scale_variables_back( x, vdat.Xscale, vdat.Xshift );
+    u=scale_variables_back( u, vdat.Uscale, vdat.Ushift );
+    if isfield(vdat,'Pscale')
+        p=scale_variables_back( p, vdat.Pscale, vdat.Pshift );
+    end
+    dx = f_unscaled(x,u,p,t,vdat);
+    dx = scale_variables( dx, vdat.Xscale, 0 );
+else
+    dx = f_unscaled(x,u,p,t,vdat);
+end
+
+%------------- END OF CODE --------------
+
+function c=g(x,u,p,t,vdat)
+
+% g - Returns the path constraint function where gl =< g(x,u,p,t) =< gu
+% Warp function
+%------------- BEGIN CODE --------------
+g_unscaled=vdat.InternalDynamics;
+ng_group=nargout(g_unscaled);
+if isfield(vdat,'Xscale')
+    x=scale_variables_back( x, vdat.Xscale, vdat.Xshift );
+    u=scale_variables_back( u, vdat.Uscale, vdat.Ushift );
+    if isfield(vdat,'Pscale')
+        p=scale_variables_back( p, vdat.Pscale, vdat.Pshift );
+    end
+end
+
+if ng_group==1
+    c=[];
+elseif ng_group==2
+    [~,c] = g_unscaled(x,u,p,t,vdat);
+else
+    [~,ceq,cneq] = g_unscaled(x,u,p,t,vdat);
+    c=[ceq cneq];
+end
+
+if isfield(vdat,'gFilter')
+    c(:,vdat.gFilter)=[];
+end
+
+if strcmp(vdat.mode.currentMode,'Feasibility')
+    c=[c-p(:,end-vdat.mode.np*2+1:end-vdat.mode.np) c+p(:,end-vdat.mode.np+1:end)];
+end
+
+
+function [dx,c] = fg(x,u,p,t,vdat)
+% fg - Returns the ODE right hand side where x'= f(x,u,p,t) and the path constraint function where gl =< g(x,u,p,t) =< gu
+% Warp function
+%------------- BEGIN CODE --------------
+fg_unscaled=vdat.InternalDynamics;
+ng_group=nargout(fg_unscaled);
+
+if isfield(vdat,'Xscale')
+    x=scale_variables_back( x, vdat.Xscale, vdat.Xshift );
+    u=scale_variables_back( u, vdat.Uscale, vdat.Ushift );
+    if isfield(vdat,'Pscale')
+        p=scale_variables_back( p, vdat.Pscale, vdat.Pshift );
+    end
+end
+
+if ng_group==1
+    c=[];
+elseif ng_group==2
+    [dx,c]=fg_unscaled(x,u,p,t,vdat);
+else
+    [dx,ceq,cneq]=fg_unscaled(x,u,p,t,vdat);
+    c=[ceq cneq];
+end
+
+if isfield(vdat,'Xscale')
+    dx = scale_variables( dx, vdat.Xscale, 0 );
+end
+
+if isfield(vdat,'gFilter')
+    c(:,vdat.gFilter)=[];
+end
+
+if strcmp(vdat.mode.currentMode,'Feasibility')
+    c=[c-p(:,end-vdat.mode.np*2+1:end-vdat.mode.np) c+p(:,end-vdat.mode.np+1:end)];
+end
+
+%------------- END OF CODE --------------
+
+
+%------------- END OF CODE --------------
+
+function cr=avrc(x,u,p,t,data)
+
+% avrc - Returns the rate constraint algebraic function where [xrl url] =<
+% avrc(x,u,p,t) =< [xru uru]
+% The function must be vectorized and
+% xi, ui, pi are column vectors taken as x(:,i), u(:,i) and p(:,i). Each
+% constraint corresponds to one column of c
+% 
+% Syntax:  cr=avrc(x,u,p,t,data)
+%
+% Inputs:
+%    x  - state vector
+%    u  - input
+%    p  - parameter
+%    t  - time
+%   data- structured variable containing the values of additional data used inside
+%          the function
+%
+% Output:
+%    cr - constraint function
+%
+%
+%------------- BEGIN CODE --------------
+[ cr ] = addRateConstraint( x,u,p,t,data );
+%------------- END OF CODE --------------
+
+
+
+function bc=b(x0,xf,u0,uf,p,t0,tf,vdat,varargin)
+% b - Returns a column vector containing the evaluation of the boundary constraints: bl =< bf(x0,xf,u0,uf,p,t0,tf) =< bu
+% Warp function
+%------------- BEGIN CODE --------------
+bc=b_unscaled(x0,xf,u0,uf,p,t0,tf,vdat,varargin);
+if isfield(vdat,'Xscale')
+    if ~isempty(bc)
+        x0=scale_variables_back( x0', vdat.Xscale, vdat.Xshift );
+        xf=scale_variables_back( xf', vdat.Xscale, vdat.Xshift );
+        u0=scale_variables_back( u0', vdat.Uscale, vdat.Ushift );
+        uf=scale_variables_back( uf', vdat.Uscale, vdat.Ushift );
+        if isfield(vdat,'Pscale')
+            p=scale_variables_back( p', vdat.Pscale, vdat.Pshift );
+        end
+        bc=b_unscaled(x0,xf,u0,uf,p,t0,tf,vdat,varargin);
+    end
+end
+
+
+%------------- END OF CODE ---------------------
+
+function dx = f_unscaled(x,u,p,t,vdat)
+% f - Returns the ODE right hand side where x'= f(x,u,p,t)
+% Warp function
+%------------- BEGIN CODE --------------
+Dynamics=vdat.InternalDynamics;
+dx = Dynamics(x,u,p,t,vdat);
+
+%------------- END OF CODE --------------
+
+function c=g_unscaled(x,u,p,t,vdat)
+
+% g - Returns the path constraint function where gl =< g(x,u,p,t) =< gu
+% Warp function
+%------------- BEGIN CODE --------------
+Dynamics=vdat.InternalDynamics;
+ng_group=nargout(Dynamics);
+
+if ng_group==1
+    c=[];
+elseif ng_group==2
+    [~,c] = Dynamics(x,u,p,t,vdat);
+else
+    [~,ceq,cneq] = Dynamics(x,u,p,t,vdat);
+    c=[ceq cneq];
+end
+
+
+%------------- END OF CODE ---------------------

--- a/exampleProblems/Brachistochrone/Brachistochrone_Dynamics_Internal.m
+++ b/exampleProblems/Brachistochrone/Brachistochrone_Dynamics_Internal.m
@@ -1,0 +1,41 @@
+function [dx] = Brachistochrone_Dynamics_Internal(x,u,p,t,vdat)
+% Brachistochrone Dynamics - Internal
+%
+% Syntax:  
+%          [dx] = Dynamics(x,u,p,t,vdat)	(Dynamics Only)
+%          [dx,g_eq] = Dynamics(x,u,p,t,vdat)   (Dynamics and Eqaulity Path Constraints)
+%          [dx,g_neq] = Dynamics(x,u,p,t,vdat)   (Dynamics and Inqaulity Path Constraints)
+%          [dx,g_eq,g_neq] = Dynamics(x,u,p,t,vdat)   (Dynamics, Equality and Ineqaulity Path Constraints)
+% 
+% Inputs:
+%    x  - state vector
+%    u  - input
+%    p  - parameter
+%    t  - time
+%    vdat - structured variable containing the values of additional data used inside
+%          the function%      
+% Output:
+%    dx - time derivative of x
+%    g_eq - constraint function for equality constraints
+%    g_neq - constraint function for inequality constraints
+%
+% Copyright (C) 2019 Yuanbo Nie, Omar Faqir, and Eric Kerrigan. All Rights Reserved.
+% The contribution of Paola Falugi, Eric Kerrigan and Eugene van Wyk for the work on ICLOCS Version 1 (2010) is kindly acknowledged.
+% This code is published under the MIT License.
+% Department of Aeronautics and Department of Electrical and Electronic Engineering,
+% Imperial College London London  England, UK 
+% ICLOCS (Imperial College London Optimal Control) Version 2.5 
+% 1 Aug 2019
+% iclocs@imperial.ac.uk
+%
+%------------- BEGIN CODE --------------
+
+g = vdat.g; 
+
+v = x(:,3);
+u = u(:,1);
+
+dx=[v.*sin(u),v.*cos(u),g*cos(u)];
+
+
+%------------- END OF CODE --------------

--- a/exampleProblems/Brachistochrone/main_Brachistochrone.m
+++ b/exampleProblems/Brachistochrone/main_Brachistochrone.m
@@ -1,0 +1,49 @@
+% main_Brachistochrone - Main script to solve the Optimal Control Problem
+%
+% Brachistochrone Problem
+%
+% Copyright (C) 2019 Yuanbo Nie, Omar Faqir, and Eric Kerrigan. All Rights Reserved.
+% The contribution of Paola Falugi, Eric Kerrigan and Eugene van Wyk for the work on ICLOCS Version 1 (2010) is kindly acknowledged.
+% This code is published under the MIT License.
+% Department of Aeronautics and Department of Electrical and Electronic Engineering,
+% Imperial College London London  England, UK 
+% ICLOCS (Imperial College London Optimal Control) Version 2.5 
+% 1 Aug 2019
+% iclocs@imperial.ac.uk
+
+
+%--------------------------------------------------------
+
+
+
+
+%% Solve the problem
+clear all;close all;format compact;
+[problem,guess]=Brachistochrone;          % Fetch the problem definition
+options= problem.settings(100);           % Get options and solver settings 
+[solution,MRHistory]=solveMyProblem( problem,guess,options);
+
+%% Generate Figures
+xx=linspace(solution.T(1,1),solution.tf,100000);
+
+figure(100)
+hold on
+plot(speval(solution,'X',1,xx),speval(solution,'X',2,xx))
+xlabel('X [m]')
+ylabel('Y [m]')
+grid on
+set(gca,'YDir','reverse');
+
+figure(101)
+hold on
+plot(xx,speval(solution,'X',3,xx))
+xlabel('Time [s]')
+ylabel('Velocity [m/s]')
+grid on
+
+figure(102)
+hold on
+plot(xx,speval(solution,'U',1,xx))
+xlabel('Time [s]')
+ylabel('Control [rad]')
+grid on

--- a/exampleProblems/Brachistochrone/settings_Brachistochrone.m
+++ b/exampleProblems/Brachistochrone/settings_Brachistochrone.m
@@ -1,0 +1,324 @@
+function options = settings_Brachistochrone(varargin)
+
+%SETTINGS - General and solver-specific settings are selected here
+% Unless specified otherwise the options are set using 0 => no and 1 => yes
+%
+% Syntax:  options = settings(varargin)
+%          When giving one input with varargin, e.g. with settings(20), will use h-method of your choice with N=20 nodes
+%          When giving two inputs with varargin, hp-LGR method will be used with two possibilities
+%           - Scalar numbers can be used for equally spaced intervals with the same polynoimial orders. For example, settings_hp(5,4) means using 5 LGR intervals each of polynomial degree of 4. 
+%           - Alternatively, can supply two arrays in the argument with customized meshing. For example, settings_hp([-1 0.3 0.4 1],[4 5 3]) will have 3 segments on the normalized interval [-1 0.3], [0.3 0.4] and [0.4 1], with polynomial order of 4, 5, and 3 respectively.
+%      
+% Output:
+%    options - Structure containing the settings
+%
+% Other m-files required: none
+% Subfunctions: none
+% MAT-files required: none
+%
+% Copyright (C) 2019 Yuanbo Nie, Omar Faqir, and Eric Kerrigan. All Rights Reserved.
+% The contribution of Paola Falugi, Eric Kerrigan and Eugene van Wyk for the work on ICLOCS Version 1 (2010) is kindly acknowledged.
+% This code is published under the MIT License.
+% Department of Aeronautics and Department of Electrical and Electronic Engineering,
+% Imperial College London London  England, UK 
+% ICLOCS (Imperial College London Optimal Control) Version 2.5 
+% 1 Aug 2019
+% iclocs@imperial.ac.uk
+
+%------------- BEGIN CODE --------------
+
+
+%% Transcription Method
+
+% Select a transcription method
+%---------------------------------------
+% - Direct collocation method ('direct_collocation')
+% - Integral residual minimization method ('integral_res_min')
+options.transcription='direct_collocation';
+
+% Solution method for integrated residual minimization
+%---------------------------------------
+% - The alternating method ('alternating')          solving integrated residual minimization and objective minimization in an alternating scheme
+% - The penalty barrier method ('weightedCost')     using a weighted objective
+options.min_res_mode='alternating';
+
+% For the alternating method, specify priorities for the solution property
+%---------------------------------------
+% - Lower integrated residual error ('low_res_error')
+% - Lower objective value ('low_cost_value')
+options.min_res_priority='low_res_error';
+
+% For penalty barrier method, provide a sequence of weights for regularization
+%---------------------------------------
+options.resCostWeight=[];
+
+% Error criteria (in addition to constraint violation error)
+%---------------------------------------
+% - local absolute error ('local_abs')      recommended for direct collocation
+% - integral residual error ('int_res')     recommended for integral residual minimization
+% - both ('both')                           most strict, convergence may be affected (not recommended unless the integrated residual minimization method is selected for result representation )
+options.errortype='local_abs';
+
+
+%% Discretization Method
+
+% Select a discretization method
+%---------------------------------------
+% Discrete-time model       ('discrete')
+% Euler method              ('euler')
+% Trapezoidal method        ('trapezoidal')
+% Hermite-Simpson method    ('hermite')
+% Global LGR method         ('globalLGR')
+% Local LGR method          ('hpLGR')
+% Automatic chosen direct collocation ('AutoDirect')
+options.discretization='trapezoidal';
+
+% Result Representation:
+%---------------------------------------
+% Direct interpolation in correspondence with the transcription method        ('default')
+% Manually selected       ('manual')
+% Representation by integrated residual minimization       ('res_min')
+% Final representation by integrated residual minimization, with intermediate mesh refinement itrations represented with default method     ('res_min_final_default')      Note: only when error criteria is set to 'both' and the local error tolerance has been fulfilled
+% Final representation by integrated residual minimization, with intermediate mesh refinement itrations represented with the manually selected method    ('res_min_final_manual')      Note: only when error criteria is set to 'both' and the local error tolerance has been fulfilled
+options.resultRep='default';
+
+% Specify the representation method when 'manual' method is selected
+%---------------------------------------
+if strcmp(options.resultRep,'manual') || strcmp(options.resultRep,'res_min_final_manual')         
+        % State representation
+        %---------------------------------------
+        %   - Piecewise linear          ('linear'), available for Euler transcription method  
+        %   - Piecewise quadratic       ('quadratic'), available for Euler and Trapezoidal transcription methods  
+        %   - Piecewise cubic           ('cubic'), available for Hermite-Simpson transcription method  
+        %   - Barycentric Lagrange Interpolation ('Barycentric'), available for LGR transcription method  
+        %   - Legendre polynomial fitting  ('Legendre'), available for LGR transcription method  
+        %   - Piecewise Cubic Hermite Interpolating Polynomial with Matlab pchip function        ('pchip'), available for all transcription methods
+        options.stateRep='pchip';
+        % Input representation
+        %---------------------------------------
+        %   - Piecewise constant        ('constant'), available for all transcription methods
+        %   - Piecewise linear          ('linear'), available for all transcription methods
+        %   - Piecewise quadratic       ('quadratic'), available for Trapezoidal transcription methods  
+        %   - Barycentric Lagrange Interpolation ('Barycentric'), available for LGR transcription method  
+        %   - Legendre polynomial fitting  ('Legendre'), available for LGR transcription method  
+        %   - Piecewise Cubic Hermite Interpolating Polynomial with Matlab pchip function        ('pchip'), available for all transcription methods
+        options.inputRep='linear';
+end
+
+% Further settings for solution representation by integrated residual minimization
+%---------------------------------------
+if strcmp(options.resultRep,'res_min') || strcmp(options.resultRep,'res_min_final_default') || strcmp(options.resultRep,'res_min_final_manual')
+        % Option on whether to match the end-point results from collocation, recommend to select No (0) 
+        options.resminRep.collmatch=0; 
+        % Tolerance for the cost value, in precentage (e.g. 0.01 represent maximum increase of 1% of the original cost value)
+        options.resminRep.costTol=0; %
+end
+
+%% Derivative generation
+
+% Derivative computation method
+%---------------------------------------
+% Analytic differentiation: analytic gradients   ('analytic')
+    % Whenever the analytic differentiation is enabled it is necessary to specify the available analytic forms for the cost function, the dynamic equations and the constraints in the appropriate files .m
+% Numerical differentiation: finite differences  ('numeric')
+% Algorithmic differentiation with Adigator      ('adigator')
+    % Make sure you provide the path to the Adigator directory of startupadigator.m
+options.derivatives='numeric';
+options.adigatorPath='path_to_adigator';
+
+% Perturbation sizes for numerical differentiation
+%---------------------------------------
+%  It is possible to select default values for the perturbations by setting  options.perturbation.H and 
+%  options.perturbation.J to the empty matrix.
+%  The default values for the gradient approximation is (eps/2)^(1/3)
+%  while for the  second derivative is (8*eps)^(1/3). 
+options.perturbation.H=[];  % Perturbation size for the second derivatives
+options.perturbation.J=[];  % Perturbation size for the first derivatives
+
+%% NLP solver
+
+% Select a NLP solver
+%---------------------------------------
+% IPOPT: recommended but needs ipopt.mex        ('ipopt')
+% fmincon                                       ('fmincon')
+% WORHP                                         ('worhp')
+options.NLPsolver='ipopt';
+
+% IPOPT settings (if required)
+%---------------------------------------
+options.ipopt.tol=1e-9;                        % Desired convergence tolerance (relative). The default value is  1e-8. 
+options.ipopt.print_level=5;                   % Print level. The valid range for this integer option is [0,12] and its default value is 5.
+options.ipopt.max_iter=5000;                   % Maximum number of iterations. The default value is 3000.
+ 
+options.ipopt.mu_strategy ='adaptive';         % Determines which barrier parameter update strategy is to be used. 
+                                               % The default value for this string option is "monotone".
+                                               % Possible values:
+                                               %   'monotone': use the monotone (Fiacco-McCormick) strategy
+                                               %   'adaptive': use the adaptive update strategy
+
+options.ipopt.hessian_approximation='exact';   %  Indicates what information for the Hessian of the Lagrangian function is                                                    
+                                               %  used by the algorithm. The default value is 'exact'.
+                                               %  Possible values:
+                                               %   'exact': Use second derivatives provided by ICLOCS.
+                                               %   'limited-memory': Perform a limited-memory quasi-Newton approximation
+					                           %		             implemented inside IPOPT
+
+options.ipopt.limited_memory_max_history=6;   % Maximum size of the history for the limited quasi-Newton Hessian approximation. The valid range for this integer option is [0, +inf) 
+                                               % and its default value is 6. 
+options.ipopt.limited_memory_max_skipping=1;  % Threshold for successive iterations where update is skipped for the quasi-Newton approximation.
+                                               % The valid range for this integer option is [1,+inf) and its default value is 2. 
+
+% fmincon settings (NOT RECOMMENDED!)
+%---------------------------------------
+% See website for detailed info
+
+% WORHP settings
+%---------------------------------------
+% need to be configured with the xml file
+
+
+%% Meshing Strategy
+
+% Type of meshing
+%---------------------------------------
+% - fixed mesh ('fixed')
+% - with local refinement of mesh ('mesh_refinement')
+% - flexible mesh with adaptively spaced segments, ONLY AVAILABLE FOR hpLGR Discretization with Direct Collocation Method ('hp_flexible')
+options.meshstrategy='fixed';
+
+% Mesh Refinement Method
+%---------------------------------------
+% Increase Polynomial Order        ('IO')
+% Add intervals                    ('AI')
+% Automatic refinement             ('Auto')
+% For current version leave the setting to Automatic
+options.MeshRefinement='Auto';
+
+% Mesh Refinement Preferences
+%---------------------------------------
+% Prioritize MR time               ('aggressive')   A relative aggressive scheme that aim to reduce the number of MR iterations and the total MR time
+% Prioritize MR efficiency         ('efficient')   A relative efficient scheme that aim to reduce the size of the problem at the end of MR iterations, making it potentially more efficient for online re-computations
+options.MRstrategy='aggressive';
+
+% Maximum number of mesh refinement iterations
+%---------------------------------------
+options.maxMRiter=50;
+
+% Discountious Input
+%---------------------------------------
+% NOTE: Not yet available in this version
+options.disContInputs=0;
+
+% Minimum and maximum time interval
+%---------------------------------------
+% Define the minimum and maximum time interval (in the same unit as in t) for the hp-flexible method and for mesh refinement schemes
+options.mintimeinterval=0.1; 
+options.maxtimeinterval=inf; 
+
+% Distribution of integration steps. 
+%---------------------------------------
+% Set tau=0 for equispaced steps.
+% Otherwise: tau is a vector of length M-1 with 0<tau(i)<1 and sum(tau)=1.
+% For discrete time system  set  tau=0.
+options.tau=0;
+
+
+%% Other Settings
+
+% Cold/Warm/Hot Start (recommended)
+%---------------------------------------
+options.start='Cold';
+
+% Automatic scaling (recommended)
+%---------------------------------------
+options.scaling=0;
+
+% Reorder of LGR Method
+%---------------------------------------
+% NOTE: For current version, leave it to off (0)
+options.reorderLGR=0;
+
+% Early termination of residual minimization if tolerance is met
+%---------------------------------------
+% For use with integral residual minimization method with the alternating scheme ONLY
+options.resminEarlyStop=0;
+
+% External Constraint Handling
+%---------------------------------------
+% For problems with large sets of inactive constraints, external constraint handling may help to reduce the compuatation cost
+% Enable or disable the external constraint handling function (1 or 0)
+options.ECH.enabled=0; 
+% A conservative buffer zone (default to 0.1, i.e. 10%)
+options.ECH.buffer_pct=0.1; 
+
+% Regularization Strategy
+%---------------------------------------
+% A regularization parameter could be setup in the problem file with problem.data.penalty.values defining the regularization sequence of weights, and problem.data.penalty.i the starting index. The parameter could be called with vdat.penalty.values(vdat.penalty.i) in problem formulation.
+% Here, multiple strategies are possible interacting with mesh refinement
+% - Off ('off')                                 
+% - Regularization priority ('reg_priority')    First change regularization paramters iteratively with warm starting resolve, then perform mesh refinement iterations
+% - Mesh Refinement priority ('MR_priority')    First perform mesh refinement iterations, then change regularization paramters iteratively with warm starting resolve
+% - Simultaneous ('simultaneous')               Perform mesh refinement and regulzarization paramter iterations simultaneously
+options.regstrategy='off';
+
+% Auto selection of h/hp method based on input formulation of the settings function call
+%---------------------------------------
+% LEAVE THIS PART UNCHANGED AND USE FUNCTION SYNTAX (AS DESCRIBED ON THE TOP) TO DEFINE THE ITEGRATION NODES
+if nargin==2
+    if strcmp(varargin{2},'h')
+        options.nodes=varargin{1}; 
+        options.discretization='hermite';
+    else
+        if length(varargin{1})==1
+            options.nsegment=varargin{1}; 
+            options.pdegree=varargin{2}; 
+        else
+            options.tau_segment=varargin{1};
+            options.npsegment=varargin{2};
+        end
+        options.discretization='hpLGR';
+    end
+else
+    options.nodes=varargin{1}; 
+end
+
+
+%% Output settings
+
+% Display computation time
+%---------------------------------------
+options.print.time=1;
+
+% Display relative local discretization error (recommended for direct transcription)
+%---------------------------------------
+options.print.relative_local_error=1;
+
+% Display cost (objective) values
+%---------------------------------------
+options.print.cost=1;
+
+
+% Plot figures
+%---------------------------------------
+% 0: Do not plot
+% 1: Plot all figures (state and input trajectory, multipliers/costate values and errors)
+% 2: Plot only the state and input trajectory
+% 3: Plot only the multipliers/costate values
+% 4: Plot only the error values (absolute local error, relative local error and absolute constraint violation error)
+options.plot=1;
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/src/problemTranscriptionSolve/transcribeOCP_eachPhase.m
+++ b/src/problemTranscriptionSolve/transcribeOCP_eachPhase.m
@@ -33,8 +33,6 @@ function [infoNLP,data,options]=transcribeOCP_eachPhase(problem,guess,options)
 % 1 Aug 2019
 % iclocs@imperial.ac.uk
 
-persistent adigatorGen
-
 checkProblem(problem);
 
 if ~isfield(problem.data,'mode')
@@ -1425,20 +1423,9 @@ end
 
 %Offline generation of adigator files
  if strcmp(options.derivatives,'adigator') 
-     if adigatorGen==1
-        if ~strcmp(options.transcription,'integral_res_min')
-            data=genAdigator4ICLOCS( options, data, n, m, np, nt, M );
-        end
-     else
-        currentFolder = pwd;
-        cd(options.adigatorPath);
-        startupadigator;
-        cd(currentFolder);
-        if ~strcmp(options.transcription,'integral_res_min')
-            data=genAdigator4ICLOCS( options, data, n, m, np, nt, M );
-        end
-        adigatorGen=1;
-     end
+    if ~strcmp(options.transcription,'integral_res_min')
+        data=genAdigator4ICLOCS( options, data, n, m, np, nt, M );
+    end
  end
 
 


### PR DESCRIPTION
- Brachistochrone example with initial position (0,0) and final position (2,2). Solved using numerical differentiation and trapezoidal discretization. Results were successfully compared to those found using other optimal-control software (namely GPOPSII).
- startupadigator (and related lines) removed from 'transcribeOCP_eachPhase.m': indeed, adigator should be considered already installed. The persisent variable 'adigatorGen' removed b/c no longer necessary.