### PR TITLE
Publish usage metrics outside protected master

### DIFF
--- a/.github/workflows/update-usage-metrics.yml
+++ b/.github/workflows/update-usage-metrics.yml
@@ -12,6 +12,9 @@ concurrency:
   group: update-usage-metrics
   cancel-in-progress: false
 
+env:
+  METRICS_BRANCH: usage-metrics
+
 jobs:
   update:
     name: Refresh GitHub usage counters
@@ -21,6 +24,11 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v6
 
+      - name: Restore previous metric files
+        run: |
+          git fetch origin "${METRICS_BRANCH}" || true
+          git checkout "origin/${METRICS_BRANCH}" -- docs/metrics || true
+
       - name: Update metric files
         env:
           GITHUB_REPOSITORY: ${{ github.repository }}
@@ -28,7 +36,7 @@ jobs:
           TRAFFIC_TOKEN: ${{ secrets.TRAFFIC_TOKEN }}
         run: python3 tools/update_github_usage_metrics.py
 
-      - name: Commit metric updates
+      - name: Publish metric updates
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
@@ -37,5 +45,5 @@ jobs:
             echo "No metric changes to commit."
           else
             git commit -m "Update GitHub usage metrics"
-            git push
+            git push --force-with-lease origin "HEAD:${METRICS_BRANCH}"
           fi

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # ICLOCS
 Imperial College London Optimal Control Software (ICLOCS)
 
-[![Recorded clones](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/ImperialCollegeLondon/ICLOCS/master/docs/metrics/clones-badge.json)](docs/metrics/github-usage.json)
-[![Release downloads](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/ImperialCollegeLondon/ICLOCS/master/docs/metrics/release-downloads-badge.json)](docs/metrics/github-usage.json)
+[![Recorded clones](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/ImperialCollegeLondon/ICLOCS/usage-metrics/docs/metrics/clones-badge.json)](https://github.com/ImperialCollegeLondon/ICLOCS/blob/usage-metrics/docs/metrics/github-usage.json)
+[![Release downloads](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/ImperialCollegeLondon/ICLOCS/usage-metrics/docs/metrics/release-downloads-badge.json)](https://github.com/ImperialCollegeLondon/ICLOCS/blob/usage-metrics/docs/metrics/github-usage.json)
 [![MATLAB CI](https://github.com/ImperialCollegeLondon/ICLOCS/actions/workflows/matlab-ci.yml/badge.svg)](https://github.com/ImperialCollegeLondon/ICLOCS/actions/workflows/matlab-ci.yml)
 
 http://www.ee.ic.ac.uk/ICLOCS/
@@ -25,7 +25,7 @@ Modernization work is tracked in [`TODO.md`](TODO.md).
 
 ## Repository usage counter
 
-This repository includes a lightweight GitHub Actions workflow that records repository usage metrics in [`docs/metrics/github-usage.json`](docs/metrics/github-usage.json). The README badges above are updated from the same metric files once the workflow has run on GitHub.
+This repository includes a lightweight GitHub Actions workflow that records repository usage metrics in `docs/metrics/github-usage.json` on the `usage-metrics` branch. The README badges above are updated from the same metric files once the workflow has run on GitHub.
 
 GitHub exposes clone traffic only for the previous 14 days, so the recorded clone counter starts from the first successful scheduled or manual workflow run and cannot reconstruct historical downloads. GitHub release asset downloads are counted separately when releases provide downloadable assets. To enable clone/view traffic collection, add a repository secret named `TRAFFIC_TOKEN` with repository Administration read access, then run the **Update usage metrics** workflow from the Actions tab.
 


### PR DESCRIPTION
## Summary
- Update the usage metrics workflow to publish metric JSON to a dedicated usage-metrics branch instead of pushing directly to protected master.
- Restore existing metric JSON from usage-metrics before each run so counters can accumulate across scheduled runs.
- Point README metric badges at the usage-metrics branch.

## Validation
- YAML parse check for .github/workflows/update-usage-metrics.yml
- git diff --check
- ASCII scan for README/workflow changes

## Notes
- This addresses the failed manual metrics run where GitHub Actions could commit metric changes but could not push to protected master.