### PR TITLE
Improve MATLAB help text for public functions

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -48,7 +48,7 @@ This list tracks repository modernization work that should avoid changing the ex
 ## Function And API Documentation
 
 - [x] Inventory public functions, templates, and user-facing entry points.
-- [ ] Add or improve MATLAB help text for public functions.
+- [x] Add or improve MATLAB help text for public functions.
 - [x] Document inputs, outputs, defaults, side effects, and assumptions.
 - [x] Generate browsable API documentation from MATLAB comments if practical.
 - [ ] Keep internal implementation comments focused on behavior that is hard to infer from code.

--- a/docs/API-INDEX.md
+++ b/docs/API-INDEX.md
@@ -407,9 +407,9 @@ python3 tools/generate_api_index.py
 | `src/auxFunctions/batchScaleGradCost.m` | function | batchScaleBack - Scale the variables back into original dimension in batches |
 | `src/auxFunctions/batchScalejacConst.m` | function | batchScaleBack - Scale the variables back into original dimension in batches |
 | `src/auxFunctions/batchScaleLagHessian.m` | function | batchScaleBack - Scale the variables back into original dimension in batches |
-| `src/auxFunctions/checkProblem.m` | function | UNTITLED Summary of this function goes here |
+| `src/auxFunctions/checkProblem.m` | function | checkProblem Validate key dimensions in an ICLOCS problem structure. |
 | `src/auxFunctions/convertHessianANStruct.m` | function | convertHessianANStruct - convert the Hessian structure to a format compatible with h method formulation of ICLOCS2 |
-| `src/auxFunctions/genSolutionPlots.m` | function | genSolutionPlots - generate plots for the obtained solution |
+| `src/auxFunctions/genSolutionPlots.m` | function | genSolutionPlots Generate standard plots for an ICLOCS solution. |
 | `src/auxFunctions/linspaceMat.m` | function | linspaceMat - Generates a matrix of linearly equally spaced points between column vectors a and b, and return in vector format |
 | `src/auxFunctions/multipleShooting.m` | function | Generate the cost,constraint and gradient information needed for the |
 | `src/auxFunctions/multipliers.m` | function | MULTIPLIERS - Extract the adjoint variables and the multipliers relative to |
@@ -429,8 +429,8 @@ python3 tools/generate_api_index.py
 | `src/auxFunctions/scale_variables_back.m` | function | scale_variables_back - scale the variables back |
 | `src/auxFunctions/setFunctionTypes.m` | function | UNTITLED Summary of this function goes here |
 | `src/auxFunctions/simulateDynamics.m` | function | simulateSolution - Simulate the obtained solution (open-loop) with ODE integration |
-| `src/auxFunctions/simulateSolution.m` | function | simulateSolution - Simulate the obtained solution (open-loop) with ODE integration |
-| `src/auxFunctions/simulateSolutionSegment.m` | function | simulateSolution - Simulate the obtained solution (open-loop) with ODE integration |
+| `src/auxFunctions/simulateSolution.m` | function | simulateSolution Simulate an optimized open-loop solution with an ODE solver. |
+| `src/auxFunctions/simulateSolutionSegment.m` | function | simulateSolutionSegment Simulate a solution over an explicit time vector. |
 | `src/auxFunctions/spkroneye.m` | function | UNTITLED Summary of this function goes here |
 | `src/constraintHandling/checkConstraintReactivation.m` | function | checkConstraintReactivation - check if certain path constraints have become |
 | `src/constraintHandling/identifyConstActive.m` | function | identifyConstActive - identify time intervals that the path constraints are potentially active |
@@ -567,7 +567,7 @@ python3 tools/generate_api_index.py
 | `src/problemTranscriptionSolve/overlapping.m` | function | OVERLAPPING - It  groups orthogonal colums of the matrix M together. |
 | `src/problemTranscriptionSolve/postProcessSolution.m` | function | postProcessSolution - post process the solution obtained from NLP solver |
 | `src/problemTranscriptionSolve/runPostSolveTasks.m` | function | runPostSolveTasks - run Post-Solve Tasks |
-| `src/problemTranscriptionSolve/solveMyProblem.m` | function | solveMyProblem - main file for solving NLPs |
+| `src/problemTranscriptionSolve/solveMyProblem.m` | function | solveMyProblem Transcribe and solve an ICLOCS optimal-control problem. |
 | `src/problemTranscriptionSolve/solveNLP.m` | function | SOLVENLP - Solve the nonlinear program and return the solution |
 | `src/problemTranscriptionSolve/solveSingleNLP_DirectCollocation.m` | function | solveSingleNLP_DirectCollocation - Solve a single nonlinear program and |
 | `src/problemTranscriptionSolve/solveSingleNLP_DirectCollocation_MultiPhase.m` | function | solveSingleNLP_DirectCollocation - Solve a single multi-phase nonlinear program and |
@@ -579,7 +579,7 @@ python3 tools/generate_api_index.py
 | `src/problemTranscriptionSolve/transcribeResMin.m` | function | transcribeResErrorAnalysis - transcribe the problem in preparation for |
 | `src/problemTranscriptionSolve/transcriptionMatrix.m` | function | TRANSCRIPTIONMATRIX -  Format matrices for transcription method |
 | `src/problemTranscriptionSolve/transcriptionMatrixRC.m` | function | TRANSCRIPTIONMATRIX -  Precalculate the jacobian calculation of rate |
-| `src/problemTranscriptionSolve/updateMyProblem.m` | function | updateMyProblem - Update problem formulation without redo transcription |
+| `src/problemTranscriptionSolve/updateMyProblem.m` | function | updateMyProblem Update selected fields of a transcribed OCP. |
 | `src/rateConstraint/addRateConstraint.m` | function | addRateConstraint - Format the implementation for rate constraints. |
 | `src/rateConstraint/getVariableRate.m` | function | getVariableRate - Obtain the variable rate of change from the discretization mesh. |
 | `src/resMinimization/collmatch_endpt.m` | function | collmatch_endpt - for obtaining integrated residual minimization solution representation with matching of direct collocation result at endpoints |
@@ -622,7 +622,7 @@ python3 tools/generate_api_index.py
 | `src/solutionInterpolation/Linsplines.m` | function | Linsplines - Approximate the trajectory in x with a linear |
 | `src/solutionInterpolation/Quadsplines.m` | function | Quadsplines - Approximate the trajectory in x with a quadratic |
 | `src/solutionInterpolation/QuadsplinesU.m` | function | QuadsplinesU - Approximate the trajectory in u with a quadratic |
-| `src/solutionInterpolation/speval.m` | function | speval - evaluate the spline functions |
+| `src/solutionInterpolation/speval.m` | function | speval Evaluate interpolated solution components at requested times. |
 | `src/thirdParty/catstruct/catstruct.m` | function | CATSTRUCT   Concatenate or merge structures with different fieldnames |
 | `tools/setupIclocsPath.m` | function | SETUPICLOCSPATH Add ICLOCS source folders to the MATLAB path. |
 | `usr/Multi Phase Problem/callback_myProblem.m` | function | t is the current iteration of the algorithm. |

--- a/src/auxFunctions/checkProblem.m
+++ b/src/auxFunctions/checkProblem.m
@@ -1,6 +1,19 @@
 function checkProblem(problem)
-%UNTITLED Summary of this function goes here
-%   Detailed explanation goes here
+%checkProblem Validate key dimensions in an ICLOCS problem structure.
+%
+% Syntax:
+%   checkProblem(problem)
+%
+% Input:
+%   problem - ICLOCS problem structure returned by a problem-definition file.
+%
+% Output:
+%   None.
+%
+% Notes:
+%   Throws an error when state, input, path-constraint, or boundary-constraint
+%   bounds and tolerances have inconsistent dimensions. Also checks for the
+%   ICLOCS 2.5 problem.data.ng_eq convention.
 
 if length(problem.states.x0l)==length(problem.states.x0u) && length(problem.states.x0l)==length(problem.states.xl) && length(problem.states.x0l)==length(problem.states.xu) && length(problem.states.x0l)==length(problem.states.xErrorTol_local) && length(problem.states.x0l)==length(problem.states.xErrorTol_integral) && length(problem.states.x0l)==length(problem.states.xConstraintTol) && length(problem.states.x0l)==length(problem.states.xfl) && length(problem.states.x0l)==length(problem.states.xfu)
 else

--- a/src/auxFunctions/genSolutionPlots.m
+++ b/src/auxFunctions/genSolutionPlots.m
@@ -1,7 +1,20 @@
 function genSolutionPlots(options, solution)
-%genSolutionPlots - generate plots for the obtained solution
+%genSolutionPlots Generate standard plots for an ICLOCS solution.
 %
-% Syntax:  [ X,Xr,U,Ur,P,x0,xf,u0,uf,p,data ] = batchScaleBack(X,Xr,U,Ur,P,x0,xf,u0,uf,p,data)
+% Syntax:
+%   genSolutionPlots(options,solution)
+%
+% Inputs:
+%   options  - Options structure used to solve the problem.
+%   solution - Solution structure returned by solveMyProblem.
+%
+% Output:
+%   None.
+%
+% Notes:
+%   Creates MATLAB figures for states, inputs, adjoints, local error estimates,
+%   and constraint violations according to the configured plot options. Supports
+%   both single-phase and multiphase solution structures.
 %
 % Copyright (C) 2019 Yuanbo Nie, Omar Faqir, and Eric Kerrigan. All Rights Reserved.
 % The contribution of Paola Falugi, Eric Kerrigan and Eugene van Wyk for the work on ICLOCS Version 1 (2010) is kindly acknowledged.

--- a/src/auxFunctions/simulateSolution.m
+++ b/src/auxFunctions/simulateSolution.m
@@ -1,16 +1,30 @@
 function [ tv, xv, uv ] = simulateSolution( varargin )
-% simulateSolution - Simulate the obtained solution (open-loop) with ODE integration
+%simulateSolution Simulate an optimized open-loop solution with an ODE solver.
 %
 % Syntax:  
-%          [ tv, xv, uv ] = simulateSolution( problem, solution)	
-%          [ tv, xv, uv ] = simulateSolution( problem, solution, odesolver)                     (Request a specific ODE solver)
-%          [ tv, xv, uv ] = simulateSolution( problem, solution, odesolver, tstep)              (Request a specific ODE solver and integration time step)
-%          [ tv, xv, uv ] = simulateSolution( problem, solution, odesolver, tstep, s_i_swarp)   (Request a specific ODE solver and integration time step, with state-input swarping)
+%   [tv,xv,uv] = simulateSolution(problem,solution)
+%   [tv,xv,uv] = simulateSolution(problem,solution,odesolver)
+%   [tv,xv,uv] = simulateSolution(problem,solution,odesolver,tstep)
+%   [tv,xv,uv] = simulateSolution(problem,solution,odesolver,tstep,stateInputSwap)
 % 
-% Output:
-%    tv - time vector 
-%    xv - state vector
-%    uv - input vector
+% Inputs:
+%   problem        - Original ICLOCS problem structure.
+%   solution       - Solution structure returned by solveMyProblem.
+%   odesolver      - Optional ODE solver name: 'ode113', 'ode45', or 'ode23'.
+%                    The default is 'ode113'.
+%   tstep          - Optional scalar simulation time step.
+%   stateInputSwap - Optional two-row index map for examples that swap selected
+%                    states and inputs during simulation.
+%
+% Outputs:
+%   tv - Time vector returned by the ODE solver.
+%   xv - Simulated state trajectory.
+%   uv - Interpolated input trajectory evaluated at tv.
+%
+% Notes:
+%   This function simulates the supplied solution and does not re-optimize. The
+%   returned input trajectory is clipped to the configured mapped-state and
+%   input bounds.
 %
 % Copyright (C) 2019 Yuanbo Nie, Omar Faqir, and Eric Kerrigan. All Rights Reserved.
 % The contribution of Paola Falugi, Eric Kerrigan and Eugene van Wyk for the work on ICLOCS Version 1 (2010) is kindly acknowledged.
@@ -101,4 +115,3 @@ if any(uv>uu)
 end
 
 end
-

--- a/src/auxFunctions/simulateSolutionSegment.m
+++ b/src/auxFunctions/simulateSolutionSegment.m
@@ -1,16 +1,26 @@
 function [ tv, xv, uv ] = simulateSolution( varargin )
-% simulateSolution - Simulate the obtained solution (open-loop) with ODE integration
+%simulateSolutionSegment Simulate a solution over an explicit time vector.
 %
 % Syntax:  
-%          [ tv, xv, uv ] = simulateSolution( problem, solution)	
-%          [ tv, xv, uv ] = simulateSolution( problem, solution, odesolver)                     (Request a specific ODE solver)
-%          [ tv, xv, uv ] = simulateSolution( problem, solution, odesolver, tstep)              (Request a specific ODE solver and integration time step)
-%          [ tv, xv, uv ] = simulateSolution( problem, solution, odesolver, tstep, s_i_swarp)   (Request a specific ODE solver and integration time step, with state-input swarping)
+%   [tv,xv,uv] = simulateSolutionSegment(problem,solution,odesolver,T)
+%   [tv,xv,uv] = simulateSolutionSegment(problem,solution,odesolver,T,stateInputSwap)
 % 
-% Output:
-%    tv - time vector 
-%    xv - state vector
-%    uv - input vector
+% Inputs:
+%   problem        - Original ICLOCS problem structure.
+%   solution       - Solution structure returned by solveMyProblem.
+%   odesolver      - ODE solver name: 'ode113', 'ode45', or 'ode23'.
+%   T              - Explicit simulation time vector.
+%   stateInputSwap - Optional two-row index map for examples that swap selected
+%                    states and inputs during simulation.
+%
+% Outputs:
+%   tv - Time vector returned by the ODE solver.
+%   xv - Simulated state trajectory.
+%   uv - Interpolated input trajectory evaluated at tv.
+%
+% Notes:
+%   This function is the segment-time-vector variant of simulateSolution. It
+%   simulates the supplied solution and does not re-optimize.
 %
 % Copyright (C) 2019 Yuanbo Nie, Omar Faqir, and Eric Kerrigan. All Rights Reserved.
 % The contribution of Paola Falugi, Eric Kerrigan and Eugene van Wyk for the work on ICLOCS Version 1 (2010) is kindly acknowledged.
@@ -98,4 +108,3 @@ if any(uv>uu)
 end
 
 end
-

--- a/src/problemTranscriptionSolve/solveMyProblem.m
+++ b/src/problemTranscriptionSolve/solveMyProblem.m
@@ -1,7 +1,30 @@
 function [ varargout ] = solveMyProblem( varargin )
-%solveMyProblem - main file for solving NLPs
+%solveMyProblem Transcribe and solve an ICLOCS optimal-control problem.
 %
-% Syntax:  [ varargout ] = solveMyProblem( problem,guess,options )
+% Syntax:
+%   [solution,status] = solveMyProblem(problem,guess,options)
+%   [solution,status,OCP] = solveMyProblem(problem,guess,options)
+%   [solution,history,OCP_MR,OCP_initial] = solveMyProblem(problem,guess,options)
+%   [...] = solveMyProblem(problem,guess,options,OCP_in)
+%
+% Inputs:
+%   problem - ICLOCS problem structure returned by a problem-definition file.
+%   guess   - Initial-guess structure for states, inputs, time, and parameters.
+%   options - Transcription, solver, mesh, derivative, print, and plot options.
+%   OCP_in  - Optional pre-transcribed OCP structure for re-solving updates.
+%
+% Outputs:
+%   solution    - Post-processed solution structure.
+%   status      - NLP solver status for fixed-mesh solves.
+%   history     - Mesh-refinement history for mesh-refinement solves.
+%   OCP         - Optional transcribed OCP data for warm starts or updates.
+%   OCP_MR      - Optional mesh-refinement OCP data.
+%   OCP_initial - Optional initial OCP data before mesh refinement.
+%
+% Notes:
+%   Defaults are supplied through options. This function may call the selected
+%   NLP solver, run post-solve analysis, print progress, and create plots
+%   depending on the supplied options.
 %
 % Copyright (C) 2019 Yuanbo Nie, Omar Faqir, and Eric Kerrigan. All Rights Reserved.
 % The contribution of Paola Falugi, Eric Kerrigan and Eugene van Wyk for the work on ICLOCS Version 1 (2010) is kindly acknowledged.

--- a/src/problemTranscriptionSolve/updateMyProblem.m
+++ b/src/problemTranscriptionSolve/updateMyProblem.m
@@ -1,16 +1,27 @@
 function [OCP_updated] = updateMyProblem(OCP_old,varargin)
-% updateMyProblem - Update problem formulation without redo transcription
+%updateMyProblem Update selected fields of a transcribed OCP.
 %
 % Syntax:  
-%          [OCP_updated] = updateMyProblem(OCP_old, 'options', values)	
+%   OCP_updated = updateMyProblem(OCP_old,'x0',x0)
+%   OCP_updated = updateMyProblem(OCP_old,'z0',z0)
+%   OCP_updated = updateMyProblem(OCP_old,'bl',bl,'bu',bu)
+%   OCP_updated = updateMyProblem(OCP_old,'userdata',userdata)
 % 
 % Inputs:
-%    OCP_old - Previous OCP formulation
-%    options - field to be updated ('x0', 'z0', 'bu', 'bl', 'userdata')
-%    values - values corresponding to options
+%   OCP_old  - Previous transcribed OCP structure.
+%   x0       - Optional updated initial state vector.
+%   z0       - Optional updated NLP decision-vector initial guess.
+%   bl       - Optional updated boundary-constraint lower bounds.
+%   bu       - Optional updated boundary-constraint upper bounds.
+%   userdata - Optional structure merged into the existing user data.
 % 
 % Output:
-%    OCP_updated - Updated OCP formulation
+%   OCP_updated - Updated OCP formulation for a later solveMyProblem call.
+%
+% Notes:
+%   This helper supports single-phase direct-collocation OCP structures. Omitted
+%   name-value pairs are left unchanged, and x0 is scaled when the stored OCP
+%   data indicates that scaling is enabled.
 %
 % Copyright (C) 2019 Yuanbo Nie, Omar Faqir, and Eric Kerrigan. All Rights Reserved.
 % The contribution of Paola Falugi, Eric Kerrigan and Eugene van Wyk for the work on ICLOCS Version 1 (2010) is kindly acknowledged.
@@ -95,4 +106,3 @@ function [OCP_updated] = updateMyProblem(OCP_old,varargin)
    OCP_updated.data.infoNLP=OCP_updated.infoNLP;
    
 end
-

--- a/src/solutionInterpolation/speval.m
+++ b/src/solutionInterpolation/speval.m
@@ -1,13 +1,23 @@
 function [  Xout] = speval( solution,solType,nidx,T)
-%speval - evaluate the spline functions
+%speval Evaluate interpolated solution components at requested times.
 %
-% Syntax:   Xout = speval( Xp,solType,nidx,T)
+% Syntax:
+%   Xout = speval(solution,solType,nidx,T)
 %
 % Inputs:
-%    solution  - solution to the OCP after post-processing.
-%    solType - 'X' for states and 'U' for input variable
-%    nidx - Return result for the nth state/input variable
-%    T - Time vector
+%   solution - Post-processed solution structure from solveMyProblem.
+%   solType  - Component type: 'X'/'state', 'U'/'input', 'dX'/'dynamics',
+%              or 'dU'.
+%   nidx     - Scalar or vector of component indices to evaluate.
+%   T        - Time vector where the interpolation is evaluated.
+%
+% Output:
+%   Xout - Matrix with one row per time value and one column per index.
+%
+% Notes:
+%   The solution must contain the interpolation fields generated during
+%   post-processing. Segmented LGR interpolation data is handled when
+%   solution.TSeg_Bar is present.
 %
 % Copyright (C) 2019 Yuanbo Nie, Omar Faqir, and Eric Kerrigan. All Rights Reserved.
 % The contribution of Paola Falugi, Eric Kerrigan and Eugene van Wyk for the work on ICLOCS Version 1 (2010) is kindly acknowledged.
@@ -84,4 +94,3 @@ for k=1:length(nidx)
 end
 
 end
-


### PR DESCRIPTION
## Summary
- Expand MATLAB help blocks for user-facing functions: solveMyProblem, updateMyProblem, simulateSolution, simulateSolutionSegment, speval, genSolutionPlots, and checkProblem.
- Regenerate docs/API-INDEX.md so the improved summaries appear in the browsable API index.
- Mark the public help-text TODO item complete.

## Validation
- git diff --check
- ASCII scan across changed MATLAB comments, TODO.md, and docs/API-INDEX.md
- python3 -B -m py_compile tools/generate_api_index.py tools/update_github_usage_metrics.py

## Notes
- Comment-only source changes; no executable MATLAB statements were changed.